### PR TITLE
Fixes #1 where a new value is set to undefined

### DIFF
--- a/ng-remember.js
+++ b/ng-remember.js
@@ -18,7 +18,7 @@ var mod = angular.module('ngRemember', [])
         }
 
         scope.$watch('value', function (newValue) {
-          localStorage.setItem(key, newValue);
+          localStorage.setItem(key, newValue || '');
         });
       }
     };


### PR DESCRIPTION
This fixes issue #1 - Value is saved even if value become undefined. The reason is that the first argument that is passed to $watch - the new value - is `undefined` when a user types something and clears the input right after.
